### PR TITLE
Document supported graphics devices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: affiner
 Type: Package
 Title: A Finer Way to Render 3D Illustrated Objects in 'grid' Using Affine Transformations
-Version: 0.1.1
+Version: 0.1.2-0
 Authors@R: c(person("Trevor L.", "Davis", role = c("aut", "cre"),
                     email = "trevor.l.davis@gmail.com",
                     comment = c(ORCID = "0000-0001-6341-4639")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+affiner 0.1.2 (development)
+===========================
+
+* The Details sections for `help("affineGrob")` and `help("isocubeGrob")` now document
+  which graphics devices are known to support the affine transformation feature (#56).
+
 affiner 0.1.1
 =============
 

--- a/R/affineGrob.r
+++ b/R/affineGrob.r
@@ -2,6 +2,8 @@
 #'
 #' `affineGrob()` is a grid grob function to facilitate
 #' using the group affine transformation features introduced in R 4.2.
+#'
+#' `r affine_transformation_support`
 #' @param grob A grid grob to perform affine transformations on.  Passed to [grid::defineGrob()] as its `src` argument.
 #' @param vp_define [grid::viewport()] to define grid group in.  Passed to [grid::defineGrob()] as its `vp` argument.
 #'                  This will cumulative with the current viewport and the `vp` argument (if any),
@@ -75,7 +77,10 @@ affineGrob <- function(grob,
 #' @importFrom grid makeContent
 #' @export
 makeContent.affine <- function(x) {
-    stopifnot(isTRUE(grDevices::dev.capabilities()$transformations))
+    if (!isTRUE(grDevices::dev.capabilities()$transformations)) {
+        stop(paste("This graphics device does not support the affine transformation feature.",
+                   "See the Details section of `help(\"affineGrob\")` for more info."))
+    }
     define <- grid::defineGrob(x$grob, vp = x$vp_define)
     use <- grid::useGrob(define$name, transform = x$transform, vp = x$vp_use)
     gl <- grid::gList(define, use)

--- a/R/isocubeGrob.r
+++ b/R/isocubeGrob.r
@@ -5,6 +5,8 @@
 #'
 #' Any `ggplot2` objects are coerced to grobs by [ggplot2::ggplotGrob()].  Depending on what you'd like
 #' to do you may want to instead manually convert a ggplot2 object `gg` to a grob with `gtable::gtable_filter(ggplot2::ggplotGrob(gg), "panel")`.
+#'
+#' `r affine_transformation_support`
 #' @param top A grid grob object to use as the top side of the cube.  ggplot2 objects will be coerced by [ggplot2::ggplotGrob()].
 #' @param right A grid grob object to use as the right side of the cube.  ggplot2 objects will be coerced by [ggplot2::ggplotGrob()].
 #' @param left A grid grob object to use as the left side of the cube.  ggplot2 objects will be coerced by [ggplot2::ggplotGrob()].
@@ -90,8 +92,6 @@ isocubeGrob <- function(top, right, left,
 #' @importFrom grid makeContent
 #' @export
 makeContent.isocube <- function(x) {
-    stopifnot(isTRUE(grDevices::dev.capabilities()$transformations))
-
     gl <- grid::gList()
     sides <- c("top", "right", "left")
     for (i in 1:3) {

--- a/R/roxygen2_inline.r
+++ b/R/roxygen2_inline.r
@@ -104,3 +104,15 @@ r2i_transform3d_plane <- paste(
 r2i_transform1d_x <- "A [Coord1D] object of length one or an object coercible to one by `as_coord1d(x, ...)`."
 r2i_transform2d_x <- "A [Coord2D] object of length one or an object coercible to one by `as_coord2d(x, ...)`."
 r2i_transform3d_x <- "A [Coord3D] object of length one or an object coercible to one by `as_coord3d(x, ...)`."
+
+affine_transformation_support <- paste(
+    "Not all graphics devices provided by `grDevices` or other R packages support the [affine transformation feature introduced in R 4.2](https://www.stat.auckland.ac.nz/~paul/Reports/GraphicsEngine/groups/groups.html).",
+    "If `isTRUE(getRversion() >= '4.2.0')` then the active graphics device should support this feature if `isTRUE(grDevices::dev.capabilities()$transformations)`.",
+    "In particular the following graphics devices should support the affine transformation feature:",
+    "",
+    "* R's [grDevices::pdf()] device",
+    "* R's 'cairo' devices e.g. [grDevices::cairo_pdf()], `grDevices::png(type = 'cairo')`, [grDevices::svg()], `grDevices::x11(type = 'cairo')`, etc. If `isTRUE(capabilities('cairo'))` then R was compiled with support for the 'cairo' devices .",
+    "* R's 'quartz' devices (since R 4.3.0) e.g. [grDevices::quartz()], `grDevices::png(type = 'quartz')`, etc. If `isTRUE(capabilities('aqua'))` then R was compiled with support for the 'quartz' devices (generally only `TRUE` on macOS systems).",
+    "* `ragg`'s devices (since v1.3.0) e.g. [ragg::agg_png()], [ragg::agg_capture()], etc.",
+    sep = "\n"
+)

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,7 +1,7 @@
 # affiner <img src="man/figures/logo.png" align="right" width="200px" alt="affiner hex sticker">
 
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/affiner)](https://cran.r-project.org/package=affiner)
-[![R-CMD-check](https://github.com/trevorld/affiner/workflows/R-CMD-check/badge.svg)](https://github.com/trevorld/affiner/actions)
+[![R-CMD-check](https://github.com/trevorld/affiner/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/trevorld/affiner/actions)
 [![Coverage Status](https://codecov.io/gh/trevorld/affiner/branch/main/graph/badge.svg)](https://app.codecov.io/gh/trevorld/affiner)
 
 *I have not heard of a finer package* --Typical R developer when asked what they have heard about `{affiner}`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # affiner <img src="man/figures/logo.png" align="right" width="200px" alt="affiner hex sticker">
 
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/affiner)](https://cran.r-project.org/package=affiner)
-[![R-CMD-check](https://github.com/trevorld/affiner/workflows/R-CMD-check/badge.svg)](https://github.com/trevorld/affiner/actions)
+[![R-CMD-check](https://github.com/trevorld/affiner/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/trevorld/affiner/actions)
 [![Coverage Status](https://codecov.io/gh/trevorld/affiner/branch/main/graph/badge.svg)](https://app.codecov.io/gh/trevorld/affiner)
 
 *I have not heard of a finer package* --Typical R developer when asked what they have heard about `{affiner}`.

--- a/man/affineGrob.Rd
+++ b/man/affineGrob.Rd
@@ -47,6 +47,17 @@ As a side effect \code{grid.affine()} draws to the active graphics device.
 \code{affineGrob()} is a grid grob function to facilitate
 using the group affine transformation features introduced in R 4.2.
 }
+\details{
+Not all graphics devices provided by \code{grDevices} or other R packages support the \href{https://www.stat.auckland.ac.nz/~paul/Reports/GraphicsEngine/groups/groups.html}{affine transformation feature introduced in R 4.2}.
+If \code{isTRUE(getRversion() >= '4.2.0')} then the active graphics device should support this feature if \code{isTRUE(grDevices::dev.capabilities()$transformations)}.
+In particular the following graphics devices should support the affine transformation feature:
+\itemize{
+\item R's \code{\link[grDevices:pdf]{grDevices::pdf()}} device
+\item R's 'cairo' devices e.g. \code{\link[grDevices:cairo]{grDevices::cairo_pdf()}}, \code{grDevices::png(type = 'cairo')}, \code{\link[grDevices:cairo]{grDevices::svg()}}, \code{grDevices::x11(type = 'cairo')}, etc. If \code{isTRUE(capabilities('cairo'))} then R was compiled with support for the 'cairo' devices .
+\item R's 'quartz' devices (since R 4.3.0) e.g. \code{\link[grDevices:quartz]{grDevices::quartz()}}, \code{grDevices::png(type = 'quartz')}, etc. If \code{isTRUE(capabilities('aqua'))} then R was compiled with support for the 'quartz' devices (generally only \code{TRUE} on macOS systems).
+\item \code{ragg}'s devices (since v1.3.0) e.g. \code{\link[ragg:agg_png]{ragg::agg_png()}}, \code{\link[ragg:agg_capture]{ragg::agg_capture()}}, etc.
+}
+}
 \examples{
 if (require("grid")) {
   grob <- grobTree(rectGrob(gp = gpar(fill = "blue", col = NA)),

--- a/man/isocubeGrob.Rd
+++ b/man/isocubeGrob.Rd
@@ -46,6 +46,16 @@ isometric cube faces by automatically wrapping around \code{affineGrob()}.
 \details{
 Any \code{ggplot2} objects are coerced to grobs by \code{\link[ggplot2:ggplotGrob]{ggplot2::ggplotGrob()}}.  Depending on what you'd like
 to do you may want to instead manually convert a ggplot2 object \code{gg} to a grob with \code{gtable::gtable_filter(ggplot2::ggplotGrob(gg), "panel")}.
+
+Not all graphics devices provided by \code{grDevices} or other R packages support the \href{https://www.stat.auckland.ac.nz/~paul/Reports/GraphicsEngine/groups/groups.html}{affine transformation feature introduced in R 4.2}.
+If \code{isTRUE(getRversion() >= '4.2.0')} then the active graphics device should support this feature if \code{isTRUE(grDevices::dev.capabilities()$transformations)}.
+In particular the following graphics devices should support the affine transformation feature:
+\itemize{
+\item R's \code{\link[grDevices:pdf]{grDevices::pdf()}} device
+\item R's 'cairo' devices e.g. \code{\link[grDevices:cairo]{grDevices::cairo_pdf()}}, \code{grDevices::png(type = 'cairo')}, \code{\link[grDevices:cairo]{grDevices::svg()}}, \code{grDevices::x11(type = 'cairo')}, etc. If \code{isTRUE(capabilities('cairo'))} then R was compiled with support for the 'cairo' devices .
+\item R's 'quartz' devices (since R 4.3.0) e.g. \code{\link[grDevices:quartz]{grDevices::quartz()}}, \code{grDevices::png(type = 'quartz')}, etc. If \code{isTRUE(capabilities('aqua'))} then R was compiled with support for the 'quartz' devices (generally only \code{TRUE} on macOS systems).
+\item \code{ragg}'s devices (since v1.3.0) e.g. \code{\link[ragg:agg_png]{ragg::agg_png()}}, \code{\link[ragg:agg_capture]{ragg::agg_capture()}}, etc.
+}
 }
 \examples{
 if (require("grid") &&

--- a/tests/testthat/test-affineGrob.r
+++ b/tests/testthat/test-affineGrob.r
@@ -1,6 +1,6 @@
 test_that("affineGrob() works", {
     skip_if_not(getRversion() >= "4.3.0")
-    skip_if_not(isTRUE(capabilities("cairo")))
+    skip_if_not(isTRUE(all(capabilities(c("cairo", "png")))))
     f <- tempfile(fileext = ".png")
     png(f, type = "cairo")
     grid.affine(grid::nullGrob())

--- a/tests/testthat/test-isocubeGrob.r
+++ b/tests/testthat/test-isocubeGrob.r
@@ -1,10 +1,10 @@
 test_that("isocubeGrob() works", {
     skip_if_not(getRversion() >= "4.3.0")
-    skip_if_not(isTRUE(capabilities("cairo")))
+    skip_if_not(isTRUE(all(capabilities(c("cairo", "png")))))
     f <- tempfile(fileext = ".png")
     png(f, type = "cairo")
     gp_text <- grid::gpar(fontsize = 72)
-    grid.isocube(top = grid::textGrob("top", gp = gp_text), 
+    grid.isocube(top = grid::textGrob("top", gp = gp_text),
                  right = grid::textGrob("right", gp = gp_text),
                  left = grid::textGrob("left", gp = gp_text))
     dev.off()


### PR DESCRIPTION
* The Details sections for `help("affineGrob")` and `help("isocubeGrob")` now document which graphics devices are known to support the affine transformation feature.
* If the active graphics device do not support this feature then the error message now tells you to read this new section for more info.

closes #56