### PR TITLE
fix: permute3d() and rotate3d() return correct transform3d class; fix docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: affiner
 Type: Package
 Title: A Finer Way to Render 3D Illustrated Objects in 'grid' Using Affine Transformations
-Version: 0.3.0-4
+Version: 0.3.0-5
 Authors@R: c(person("Trevor L.", "Davis", role = c("aut", "cre"),
                     email = "trevor.l.davis@gmail.com",
                     comment = c(ORCID = "0000-0001-6341-4639")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ affiner 0.3.0 (development)
 * `rgl::plot3d()` method added for `Plane3D` objects (wraps `rgl::planes3d()`).
 * `dot_product1d()`, `dot_product2d()`, and `dot_product3d()` are new exported functions that compute the dot (inner) product of two coordinate vectors (#61).
   You may also (continue to) use the `*` and (if R >= 4.3) the `%*%` operators to compute the dot (inner) product.
+* `permute3d()` now correctly returns a `transform3d` object instead of a `transform2d` object.
+* `rotate3d()` now correctly returns a `transform3d` object instead of a plain matrix.
 * `shear3d()` now correctly returns a `transform3d` object instead of a `transform2d` object.
 
 affiner 0.2.1

--- a/R/affine.R
+++ b/R/affine.R
@@ -1,6 +1,6 @@
 #' 1D affine transformation matrices
 #'
-#' `transform1d()`, `reflect1d()`, `scale2d()`,
+#' `transform1d()`, `reflect1d()`, `scale1d()`,
 #'  and `translate1d()` create 1D affine transformation matrix objects.
 #'
 #' \describe{
@@ -15,7 +15,7 @@
 #' Note the [Coord1D] class object methods auto-pre-multiply affine transformations
 #' when "method chaining" so pre-multiplying affine transformation matrices
 #' to do a single cumulative transformation instead of a method chain of multiple transformations
-#' will not improve performance as much as as it does in other R packages.
+#' will not improve performance as much as it does in other R packages.
 #'
 #' To convert a pre-multiplied 1D affine transformation matrix to a post-multiplied one
 #' simply compute its transpose using [t()].  To get an inverse transformation matrix
@@ -36,7 +36,7 @@
 #'   clone()$
 #'   transform(mat)
 #'
-#' # The equivalent result appyling affine transformations via method chaining
+#' # The equivalent result applying affine transformations via method chaining
 #' p2 <- p$
 #'   clone()$
 #'   transform(diag(2))$
@@ -77,7 +77,7 @@ transform1d <- function(mat = diag(2L)) {
 #' Note the [Coord2D] class object methods auto-pre-multiply affine transformations
 #' when "method chaining" so pre-multiplying affine transformation matrices
 #' to do a single cumulative transformation instead of a method chain of multiple transformations
-#' will not improve performance as much as as it does in other R packages.
+#' will not improve performance as much as it does in other R packages.
 #'
 #' To convert a pre-multiplied 2D affine transformation matrix to a post-multiplied one
 #' simply compute its transpose using [t()].  To get an inverse transformation matrix
@@ -101,7 +101,7 @@ transform1d <- function(mat = diag(2L)) {
 #'   clone()$
 #'   transform(mat)
 #'
-#' # The equivalent result appyling affine transformations via method chaining
+#' # The equivalent result applying affine transformations via method chaining
 #' p2 <- p$
 #'   clone()$
 #'   transform(diag(3L))$
@@ -142,7 +142,7 @@ transform2d <- function(mat = diag(3L)) {
 #' Note the [Coord3D] class object methods auto-pre-multiply affine transformations
 #' when "method chaining" so pre-multiplying affine transformation matrices
 #' to do a single cumulative transformation instead of a method chain of multiple transformations
-#' will not improve performance as much as as it does in other R packages.
+#' will not improve performance as much as it does in other R packages.
 #'
 #' To convert a pre-multiplied 3D affine transformation matrix to a post-multiplied one
 #' simply compute its transpose using [t()].  To get an inverse transformation matrix
@@ -164,7 +164,7 @@ transform2d <- function(mat = diag(3L)) {
 #'   clone()$
 #'   transform(mat)
 #'
-#' # The equivalent result appyling affine transformations via method chaining
+#' # The equivalent result applying affine transformations via method chaining
 #' p2 <- p$
 #'   clone()$
 #'   transform(diag(4L))$
@@ -305,7 +305,7 @@ permute3d <- function(permutation = c("xyz", "xzy", "yxz", "yzx", "zyx", "zxy"))
 			nrow = 4
 		)
 	)
-	new_transform2d(mat)
+	new_transform3d(mat)
 }
 
 #' @rdname transform1d
@@ -501,7 +501,7 @@ rotate3d <- function(axis = as_coord3d("z-axis"), theta = angle(0), ...) {
 
 	mat <- diag(4L)
 	mat[1:3, 1:3] <- R
-	mat
+	new_transform3d(mat)
 }
 
 # "cross" product matrix

--- a/R/coord.R
+++ b/R/coord.R
@@ -1,6 +1,6 @@
 #' 1D coordinate vector R6 Class
 #'
-#' `Coord1D` is an [R6::R6Class()] object representing two-dimensional points
+#' `Coord1D` is an [R6::R6Class()] object representing one-dimensional points
 #' represented by Cartesian Coordinates.
 #'
 #' @examples

--- a/R/has_overlap2d.R
+++ b/R/has_overlap2d.R
@@ -279,7 +279,8 @@ ellipse_bracket_overlap <- function(e, other, n, tol = sqrt(.Machine$double.eps)
 	}
 	warning(
 		"Exact overlap detection is not yet supported for non-circular ellipses; ",
-		"the result is in the boundary region between the inner and outer polygon approximations."
+		"the result is in the boundary region between the inner and outer polygon approximations. ",
+		"Increase `n` for a tighter approximation."
 	)
 	NA
 }

--- a/R/polygon.R
+++ b/R/polygon.R
@@ -52,7 +52,7 @@ Polygon2D <- R6Class(
 			}
 			invisible(self)
 		},
-		#' @param mat `r r2i_transform1d_mat`
+		#' @param mat `r r2i_transform2d_mat`
 		transform = function(mat = transform2d()) {
 			private$hull_cache <- NULL
 			private$normals_cache <- NULL

--- a/man/Coord1D.Rd
+++ b/man/Coord1D.Rd
@@ -4,7 +4,7 @@
 \alias{Coord1D}
 \title{1D coordinate vector R6 Class}
 \description{
-\code{Coord1D} is an \code{\link[R6:R6Class]{R6::R6Class()}} object representing two-dimensional points
+\code{Coord1D} is an \code{\link[R6:R6Class]{R6::R6Class()}} object representing one-dimensional points
 represented by Cartesian Coordinates.
 }
 \examples{

--- a/man/Polygon2D.Rd
+++ b/man/Polygon2D.Rd
@@ -111,11 +111,12 @@ concave.}
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{mat}}{A 2x2 matrix representing a post-multiplied affine transformation matrix.
-The last \strong{column} must be equal to \code{c(0, 1)}.
-If the last \strong{row} is \code{c(0, 1)} you may need to transpose it
+\item{\code{mat}}{A 3x3 matrix representing a post-multiplied affine transformation matrix.
+The last \strong{column} must be equal to \code{c(0, 0, 1)}.
+If the last \strong{row} is \code{c(0, 0, 1)} you may need to transpose it
 to convert it from a pre-multiplied affine transformation matrix to a post-multiplied one.
-If a 1x1 matrix we'll quietly add a final column/row equal to \code{c(0, 1)}.}
+If a 2x2 matrix (such as a 2x2 post-multiplied 2D rotation matrix)
+we'll quietly add a final column/row equal to \code{c(0, 0, 1)}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/transform1d.Rd
+++ b/man/transform1d.Rd
@@ -39,7 +39,7 @@ such as "origin".}
 A 2x2 post-multiplied affine transformation matrix with classes "transform1d" and "at_matrix"
 }
 \description{
-\code{transform1d()}, \code{reflect1d()}, \code{scale2d()},
+\code{transform1d()}, \code{reflect1d()}, \code{scale1d()},
 and \code{translate1d()} create 1D affine transformation matrix objects.
 }
 \details{
@@ -55,7 +55,7 @@ post-multiplied and therefore should \strong{not} be multiplied in reverse order
 Note the \link{Coord1D} class object methods auto-pre-multiply affine transformations
 when "method chaining" so pre-multiplying affine transformation matrices
 to do a single cumulative transformation instead of a method chain of multiple transformations
-will not improve performance as much as as it does in other R packages.
+will not improve performance as much as it does in other R packages.
 
 To convert a pre-multiplied 1D affine transformation matrix to a post-multiplied one
 simply compute its transpose using \code{\link[=t]{t()}}.  To get an inverse transformation matrix
@@ -74,7 +74,7 @@ p1 <- p$
   clone()$
   transform(mat)
 
-# The equivalent result appyling affine transformations via method chaining
+# The equivalent result applying affine transformations via method chaining
 p2 <- p$
   clone()$
   transform(diag(2))$

--- a/man/transform2d.Rd
+++ b/man/transform2d.Rd
@@ -84,7 +84,7 @@ post-multiplied and therefore should \strong{not} be multiplied in reverse order
 Note the \link{Coord2D} class object methods auto-pre-multiply affine transformations
 when "method chaining" so pre-multiplying affine transformation matrices
 to do a single cumulative transformation instead of a method chain of multiple transformations
-will not improve performance as much as as it does in other R packages.
+will not improve performance as much as it does in other R packages.
 
 To convert a pre-multiplied 2D affine transformation matrix to a post-multiplied one
 simply compute its transpose using \code{\link[=t]{t()}}.  To get an inverse transformation matrix
@@ -106,7 +106,7 @@ p1 <- p$
   clone()$
   transform(mat)
 
-# The equivalent result appyling affine transformations via method chaining
+# The equivalent result applying affine transformations via method chaining
 p2 <- p$
   clone()$
   transform(diag(3L))$

--- a/man/transform3d.Rd
+++ b/man/transform3d.Rd
@@ -113,7 +113,7 @@ post-multiplied and therefore should \strong{not} be multiplied in reverse order
 Note the \link{Coord3D} class object methods auto-pre-multiply affine transformations
 when "method chaining" so pre-multiplying affine transformation matrices
 to do a single cumulative transformation instead of a method chain of multiple transformations
-will not improve performance as much as as it does in other R packages.
+will not improve performance as much as it does in other R packages.
 
 To convert a pre-multiplied 3D affine transformation matrix to a post-multiplied one
 simply compute its transpose using \code{\link[=t]{t()}}.  To get an inverse transformation matrix
@@ -133,7 +133,7 @@ p1 <- p$
   clone()$
   transform(mat)
 
-# The equivalent result appyling affine transformations via method chaining
+# The equivalent result applying affine transformations via method chaining
 p2 <- p$
   clone()$
   transform(diag(4L))$

--- a/tests/testthat/test-affine.R
+++ b/tests/testthat/test-affine.R
@@ -74,6 +74,8 @@ test_that("permute2d()", {
 })
 
 test_that("permute3d()", {
+	expect_true(is_transform3d(permute3d("xzy")))
+
 	x <- c(2, 5, 7)
 	y <- c(3, 4, 6)
 	z <- c(4, 9, 3)
@@ -331,6 +333,8 @@ test_that("rotate2d()", {
 })
 
 test_that("rotate3d()", {
+	expect_true(is_transform3d(rotate3d("z-axis", degrees(90))))
+
 	skip_if_not_installed("withr")
 	withr::local_options(affiner_options(default = TRUE))
 	x <- c(2, 5, 7)


### PR DESCRIPTION
- permute3d() called new_transform2d() instead of new_transform3d()
- rotate3d() returned a bare matrix instead of a transform3d object
- Fix transform1d title listing scale2d() instead of scale1d()
- Fix "as much as as it does" doubled word (3 instances)
- Fix "appyling" typo (3 instances)
- Fix Coord1D description saying "two-dimensional"
- Fix Polygon2D$transform() @param tag referencing r2i_transform1d_mat
- Improve ellipse_bracket_overlap() warning to suggest increasing n
- Add is_transform3d() class checks for permute3d() and rotate3d() tests

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
